### PR TITLE
App Admin debug options

### DIFF
--- a/src/components/AppAdmin/AppAdmin.tsx
+++ b/src/components/AppAdmin/AppAdmin.tsx
@@ -7,6 +7,7 @@ import { browser, device, os } from '@/utils/detect'
 import { productionLog } from '@/utils/log'
 import { getRuntimeEnv, isDevEnv } from '@/utils/runtime-env'
 
+import useAppAdmin from '@/hooks/use-app-admin'
 import useWindowSize from '@/hooks/use-window-size'
 
 export interface AppAdminProps {
@@ -26,12 +27,15 @@ export interface ViewProps extends AppAdminProps {
 export const View: FC<ViewProps> = ({ className, env, date, commit, version }) => {
   const { width, height } = useWindowSize()
 
+  const { options, changeOption, resetOptions } = useAppAdmin()
+
   const [open, setOpen] = useState(!!process.env.STORYBOOK || env !== 'local')
   const [render, setRender] = useState(false)
   const [removed, setRemoved] = useState(false)
   const [expanded, setExpanded] = useState(!!process.env.STORYBOOK)
   const [buildOpen, buildSetOpen] = useState(true)
   const [deviceOpen, deviceSetOpen] = useState(true)
+  const [optionsOpen, optionsSetOpen] = useState(true)
 
   const toggleOpen = useCallback(() => {
     if (open) setExpanded(false)
@@ -109,9 +113,34 @@ export const View: FC<ViewProps> = ({ className, env, date, commit, version }) =
                 )}
               </div>
 
+              <div className={classNames(css.section, { [css.closed]: optionsOpen })}>
+                <h3 className={css.title} onClick={() => optionsSetOpen(!optionsOpen)}>
+                  Options
+                </h3>
+                {optionsOpen && (
+                  <ul>
+                    <li>
+                      <label>
+                        Animate in home
+                        <input
+                          type="checkbox"
+                          onChange={() => {
+                            changeOption('animateInHome', !options.animateInHome)
+                          }}
+                          checked={options.animateInHome as boolean}
+                        />
+                      </label>
+                    </li>
+                  </ul>
+                )}
+              </div>
+
               <div className={css.section}>
                 <h3 className={css.title} onClick={() => setRemoved(true)}>
                   Remove Admin from DOM
+                </h3>
+                <h3 className={css.title} onClick={() => resetOptions()}>
+                  Reset options
                 </h3>
               </div>
             </div>

--- a/src/components/PageHome/PageHome.tsx
+++ b/src/components/PageHome/PageHome.tsx
@@ -8,6 +8,8 @@ import { Content, PageHandle, PageProps } from '@/data/types'
 
 import copy from '@/utils/copy'
 
+import useAppAdmin from '@/hooks/use-app-admin'
+
 export interface PageHomeProps extends PageProps {
   // List here all props that are public and settable by the Layout component.
   content: Content['pageHome']
@@ -25,6 +27,8 @@ export const View: FC<ViewProps> = ({ content, onReady }) => {
 
   const handleRef = useRef<PageHandle>(null)
 
+  const { options } = useAppAdmin()
+
   useEffect(() => {
     gsap.set(rootRef.current, { opacity: 0 })
     onReady?.(handleRef)
@@ -32,12 +36,16 @@ export const View: FC<ViewProps> = ({ content, onReady }) => {
 
   useImperativeHandle(handleRef, () => ({
     animateIn: () => {
-      return gsap
-        .timeline()
-        .to(rootRef.current, { opacity: 1 }, 0)
-        .fadeIn(titleRef.current, 0)
-        .fadeIn(descriptionRef.current, 0.2)
-        .fadeIn(listRef.current?.childNodes, { stagger: 0.1 }, 0.4)
+      if (options.animateInHome) {
+        return gsap
+          .timeline()
+          .to(rootRef.current, { opacity: 1 }, 0)
+          .fadeIn(titleRef.current, 0)
+          .fadeIn(descriptionRef.current, 0.2)
+          .fadeIn(listRef.current?.childNodes, { stagger: 0.1 }, 0.4)
+      } else {
+        return gsap.set(rootRef.current, { opacity: 1 })
+      }
     },
     animateOut: () => gsap.timeline().to(rootRef.current, { opacity: 0 })
   }))

--- a/src/hooks/use-app-admin.ts
+++ b/src/hooks/use-app-admin.ts
@@ -1,0 +1,48 @@
+import { useCallback, useState } from 'react'
+
+import CookieService from '@/services/cookie'
+
+const localStorageOptions = btoa('options')
+const initialOptions = {
+  animateInHome: true
+}
+
+function useAppAdmin() {
+  const [options, setOptions] = useState<{ [key: string]: unknown }>(() => {
+    return CookieService.get(localStorageOptions)
+      ? JSON.parse(atob(CookieService.get(localStorageOptions) as string))
+      : initialOptions
+  })
+
+  const changeOption = useCallback(
+    (key: string, value: boolean | string) => {
+      const newValue = { ...options, [key]: value }
+
+      CookieService.set(localStorageOptions, btoa(JSON.stringify(newValue)))
+      setOptions(newValue)
+    },
+    [options]
+  )
+
+  const getOption = useCallback(
+    (option?: string) => {
+      return option ? options[option] : options
+    },
+    [options]
+  )
+
+  const resetOptions = useCallback(() => {
+    CookieService.delete(localStorageOptions)
+
+    setOptions(initialOptions)
+  }, [])
+
+  return {
+    options,
+    resetOptions,
+    getOption,
+    changeOption
+  }
+}
+
+export default useAppAdmin

--- a/src/services/cookie.ts
+++ b/src/services/cookie.ts
@@ -14,6 +14,10 @@ class Service {
     return Cookies.get(name)
   }
 
+  delete = (name: string) => {
+    return Cookies.remove(name)
+  }
+
   listen = (listener: CookieListener) => {
     if (!this.listeners.includes(listener)) {
       this.listeners.push(listener)


### PR DESCRIPTION
- add persistent options section to app admin
- create `useAppAdmin` hook for get, set, and delete some app admin option
- add how to use the options on component level example on `PageHome` component

https://github.com/Experience-Monks/nextjs-boilerplate/assets/879968/ce89a45e-d3d1-4aae-8964-cd7c5b8ea651

