### PR TITLE
fix: add no-save to npm install

### DIFF
--- a/.circleci/commands/main.yml
+++ b/.circleci/commands/main.yml
@@ -37,7 +37,7 @@ commands:
             npm set-script preinstall ""
             npm set-script prepare ""
             npm set cache .npm
-            npm install --prefer-offline --no-audit
+            npm install --prefer-offline --no-audit --no-save
 
   generate-preview-hash:
     steps:


### PR DESCRIPTION
We noticed that the cache created by the package-lock.json was never being used as the `npm set-script` commands alter the pacakge.json and the package-lock.json creating a different checksum. Adding the `--no-save` flag ensures it does not create a new package-lock.json

<!--
Please make sure to read the Contributing Guidelines: CONTRIBUTING.md
-->

<!--- JIRA Ticket Link -->
Jira Ticket ID: <JIRA Ticket ID> <!--- Example: JRA-34 -->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

<!--- Describe the problem briefly or reference related issues -->

## Solution Description

<!--- Describe your changes in detail -->

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [ ] N/A

**Aditional comments:**
